### PR TITLE
Valgrind warning fixes

### DIFF
--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -510,7 +510,7 @@ static void parse_args(int argc, char **argv, twolame_options * encopts)
         }
     }
 
-
+    free(shortopts);
 
     // Look for the input and output file names
     argc -= optind;

--- a/libtwolame/psycho_3.c
+++ b/libtwolame/psycho_3.c
@@ -532,9 +532,9 @@ void psycho_3(twolame_options * glopts, short int buffer[2][1152], FLOAT scale[2
     FLOAT sample[BLKSIZE];
 
     FLOAT energy[BLKSIZE];
-    FLOAT power[HBLKSIZE];
+    FLOAT power[HBLKSIZE] = {0};
     FLOAT Xtm[HBLKSIZE], Xnm[HBLKSIZE];
-    int tonelabel[HBLKSIZE], noiselabel[HBLKSIZE];
+    int tonelabel[HBLKSIZE], noiselabel[HBLKSIZE] = {0};
     FLOAT LTg[HBLKSIZE];
     FLOAT Lsb[SBLIMIT];
 


### PR DESCRIPTION
This patch fixes valgrind warnings.

That said in psycho model 3, the code shouldn't really be reading values which are zeroed out but it's better I think than reading uninitialised values
