### PR TITLE
Fixed return value

### DIFF
--- a/libtwolame/get_set.c
+++ b/libtwolame/get_set.c
@@ -505,6 +505,7 @@ int twolame_set_DAB_scf_crc(twolame_options * glopts,
         fprintf(stderr, "Invalid size of DAB scf-crc field\n");
         return (-1);
     }
+    return (0);
 }
 
 


### PR DESCRIPTION
The MS C compiler only issue warnings (by default) for this kind of things. Sorry.
Best regards /Jörgen
