### PR TITLE
Silence a gcc warning raised as an error

### DIFF
--- a/simplefrontend/audio_wave.c
+++ b/simplefrontend/audio_wave.c
@@ -141,7 +141,8 @@ wave_info_t *wave_init(char *inPath)
     /********************************************/
 
     fseek(file, 0, SEEK_SET);
-    fread(wave_header_buffer, 1, 40, file);
+    if (fread(wave_header_buffer, 1, 40, file) != 40)
+        return (NULL);
 
     if (wave_header_buffer[8] == 'W' && wave_header_buffer[9] == 'A'
         && wave_header_buffer[10] == 'V' && wave_header_buffer[11] == 'E') {


### PR DESCRIPTION
During compilation, gcc is set to handle any warning as a real error, and so it stops building when you do not use the returned value from "fread".
This simple patch fixes this.