### PR TITLE
Add free format encoding

### DIFF
--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -33,7 +33,7 @@
 
 
 
-/* 
+/*
   Global Variables
 */
 int use_raw = FALSE;            // use raw input?
@@ -50,7 +50,7 @@ char outputfilename[MAX_NAME_SIZE] = "\0";
 
 
 
-/* 
+/*
   new_extension()
   Puts a new extension name on a file name <filename>.
   Removes the last extension name, if any.
@@ -87,7 +87,7 @@ static void new_extension(char *filename, char *extname, char *newname)
         strncpy(newname, filename, dotpos);
         newname[dotpos] = '\0';
     }
-    // Make sure there is room in the string for the 
+    // Make sure there is room in the string for the
     // new filename and the extension
     if (strlen(newname) + strlen(extname) + 1 < MAX_NAME_SIZE) {
         strcat(newname, extname);
@@ -145,8 +145,8 @@ static void print_filenames(int verbosity)
 
 
 
-/* 
-  usage_long() 
+/*
+  usage_long()
   Display the extended usage information
 */
 static void usage_long()
@@ -188,6 +188,7 @@ static void usage_long()
     fprintf(stderr, "\t-l, --ath lev            ATH level (default 0.0)\n");
     fprintf(stderr, "\t-q, --quick num          only calculate psy model every num frames\n");
     fprintf(stderr, "\t-S, --single-frame       only encode a single frame of MPEG Audio\n");
+    fprintf(stderr, "\t    --freeformat         create a free format bitstream\n");
 
 
     fprintf(stderr, "\nMiscellaneous Options\n");
@@ -220,8 +221,8 @@ static void usage_long()
 
 
 
-/* 
-  usage_short() 
+/*
+  usage_short()
   Display the short usage information
 */
 static void usage_short()
@@ -275,8 +276,8 @@ static char *build_shortopt_string(struct option *opts)
 
 
 
-/* 
-  parse_args() 
+/*
+  parse_args()
   Parse the command line arguments
 */
 static void parse_args(int argc, char **argv, twolame_options * encopts)
@@ -308,6 +309,7 @@ static void parse_args(int argc, char **argv, twolame_options * encopts)
         {"ath", required_argument, NULL, 'l'},
         {"quick", required_argument, NULL, 'q'},
         {"single-frame", no_argument, NULL, 'S'},
+        {"freeformat", no_argument, NULL, 1009},
 
         // Misc
         {"copyright", no_argument, NULL, 'c'},
@@ -443,8 +445,11 @@ static void parse_args(int argc, char **argv, twolame_options * encopts)
             single_frame_mode = TRUE;
             break;
 
+        case 1009:
+            twolame_set_freeformat(encopts, TRUE);
+            break;
 
-            // Miscellaneous 
+            // Miscellaneous
         case 'c':
             twolame_set_copyright(encopts, TRUE);
             break;
@@ -536,7 +541,7 @@ static void parse_args(int argc, char **argv, twolame_options * encopts)
         usage_short();
     }
     if (outputfilename[0] == '\0' && strcmp(inputfilename, "-") != 0) {
-        // Create output filename from the inputfilename 
+        // Create output filename from the inputfilename
         // and change the suffix
         new_extension(inputfilename, OUTPUT_SUFFIX, outputfilename);
     }
@@ -601,7 +606,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "Error: mp2buffer memory allocation failed\n");
         exit(ERR_MEM_ALLOC);
     }
-    // Initialise Encoder Options Structure 
+    // Initialise Encoder Options Structure
     encopts = twolame_init();
     if (encopts == NULL) {
         fprintf(stderr, "Error: initializing libtwolame encoder failed.\n");
@@ -626,7 +631,7 @@ int main(int argc, char **argv)
     if (twolame_get_verbosity(encopts) > 1) {
         inputfile->print_info(inputfile);
     }
-    // Use information from input file to configure libtwolame 
+    // Use information from input file to configure libtwolame
     twolame_set_num_channels(encopts, sfinfo.channels);
     twolame_set_in_samplerate(encopts, sfinfo.samplerate);
 
@@ -729,11 +734,11 @@ int main(int argc, char **argv)
     if (inputfile->error_str(inputfile)) {
         fprintf(stderr, "Error reading from input file: %s\n", inputfile->error_str(inputfile));
     }
-    // 
+    //
     // flush any remaining audio. (don't send any new audio data) There
     // should only ever be a max of 1 frame on a flush. There may be zero
     // frames if the audio data was an exact multiple of 1152
-    // 
+    //
     mp2fill_size = twolame_encode_flush(encopts, mp2buffer, MP2_BUF_SIZE);
     if (mp2fill_size > 0) {
         int bytes_out = fwrite(mp2buffer, sizeof(unsigned char), mp2fill_size, outputfile);

--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -33,7 +33,7 @@
 
 
 
-/*
+/* 
   Global Variables
 */
 int use_raw = FALSE;            // use raw input?
@@ -50,7 +50,7 @@ char outputfilename[MAX_NAME_SIZE] = "\0";
 
 
 
-/*
+/* 
   new_extension()
   Puts a new extension name on a file name <filename>.
   Removes the last extension name, if any.
@@ -87,7 +87,7 @@ static void new_extension(char *filename, char *extname, char *newname)
         strncpy(newname, filename, dotpos);
         newname[dotpos] = '\0';
     }
-    // Make sure there is room in the string for the
+    // Make sure there is room in the string for the 
     // new filename and the extension
     if (strlen(newname) + strlen(extname) + 1 < MAX_NAME_SIZE) {
         strcat(newname, extname);
@@ -145,8 +145,8 @@ static void print_filenames(int verbosity)
 
 
 
-/*
-  usage_long()
+/* 
+  usage_long() 
   Display the extended usage information
 */
 static void usage_long()
@@ -221,8 +221,8 @@ static void usage_long()
 
 
 
-/*
-  usage_short()
+/* 
+  usage_short() 
   Display the short usage information
 */
 static void usage_short()
@@ -276,8 +276,8 @@ static char *build_shortopt_string(struct option *opts)
 
 
 
-/*
-  parse_args()
+/* 
+  parse_args() 
   Parse the command line arguments
 */
 static void parse_args(int argc, char **argv, twolame_options * encopts)
@@ -449,7 +449,7 @@ static void parse_args(int argc, char **argv, twolame_options * encopts)
             twolame_set_freeformat(encopts, TRUE);
             break;
 
-            // Miscellaneous
+            // Miscellaneous 
         case 'c':
             twolame_set_copyright(encopts, TRUE);
             break;
@@ -541,7 +541,7 @@ static void parse_args(int argc, char **argv, twolame_options * encopts)
         usage_short();
     }
     if (outputfilename[0] == '\0' && strcmp(inputfilename, "-") != 0) {
-        // Create output filename from the inputfilename
+        // Create output filename from the inputfilename 
         // and change the suffix
         new_extension(inputfilename, OUTPUT_SUFFIX, outputfilename);
     }
@@ -606,7 +606,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "Error: mp2buffer memory allocation failed\n");
         exit(ERR_MEM_ALLOC);
     }
-    // Initialise Encoder Options Structure
+    // Initialise Encoder Options Structure 
     encopts = twolame_init();
     if (encopts == NULL) {
         fprintf(stderr, "Error: initializing libtwolame encoder failed.\n");
@@ -631,7 +631,7 @@ int main(int argc, char **argv)
     if (twolame_get_verbosity(encopts) > 1) {
         inputfile->print_info(inputfile);
     }
-    // Use information from input file to configure libtwolame
+    // Use information from input file to configure libtwolame 
     twolame_set_num_channels(encopts, sfinfo.channels);
     twolame_set_in_samplerate(encopts, sfinfo.samplerate);
 
@@ -734,11 +734,11 @@ int main(int argc, char **argv)
     if (inputfile->error_str(inputfile)) {
         fprintf(stderr, "Error reading from input file: %s\n", inputfile->error_str(inputfile));
     }
-    //
+    // 
     // flush any remaining audio. (don't send any new audio data) There
     // should only ever be a max of 1 frame on a flush. There may be zero
     // frames if the audio data was an exact multiple of 1152
-    //
+    // 
     mp2fill_size = twolame_encode_flush(encopts, mp2buffer, MP2_BUF_SIZE);
     if (mp2fill_size > 0) {
         int bytes_out = fwrite(mp2buffer, sizeof(unsigned char), mp2fill_size, outputfile);

--- a/libtwolame/common.h
+++ b/libtwolame/common.h
@@ -277,6 +277,7 @@ struct twolame_options_struct {
     int do_energy_levels;       // Write energy level information into the end of the frame [FALSE]
     int num_ancillary_bits;     // Number of reserved ancillary bits [0] (Currently only available
     // for non-VBR modes)
+    int freeformat;             // [FALSE] TRUE
 
     // Psychoacoustic Model options
     int psymodel;               // -1, 0, 1, 2, [3], 4 Psy model number

--- a/libtwolame/get_set.c
+++ b/libtwolame/get_set.c
@@ -411,6 +411,16 @@ const char *twolame_get_version_name(twolame_options * glopts)
     return twolame_mpeg_version_name(glopts->version);
 }
 
+int twolame_set_freeformat(twolame_options * glopts, int freef)
+{
+    if (freef) {
+        glopts->freeformat = TRUE;
+    } else {
+        glopts->freeformat = FALSE;
+    }
+
+    return (0);
+}
 
 
 

--- a/libtwolame/twolame.c
+++ b/libtwolame/twolame.c
@@ -76,6 +76,7 @@ twolame_options *twolame_init(void)
     newoptions->psymodel = 3;
     newoptions->bitrate = -1;   // Default bitrate is set in init_params
     newoptions->vbr = FALSE;
+    newoptions->freeformat = FALSE;
     newoptions->vbrlevel = 5.0;
     newoptions->athlevel = 0.0;
 
@@ -141,11 +142,16 @@ static int init_header_info(twolame_options * glopts)
         return -1;
     }
     // Convert the bitrate to the an index 
-    header->bitrate_index = twolame_get_bitrate_index(glopts->bitrate, header->version);
-    if (header->bitrate_index < 0) {
-        fprintf(stderr, "Not a valid bitrate (%i) for MPEG version '%s'\n", glopts->bitrate,
-                twolame_mpeg_version_name(glopts->version));
-        return -1;
+    if (glopts->freeformat)
+        header->bitrate_index = 0;
+    else
+    {
+        header->bitrate_index = twolame_get_bitrate_index(glopts->bitrate, header->version);
+        if (header->bitrate_index < 0) {
+            fprintf(stderr, "Not a valid bitrate (%i) for MPEG version '%s'\n", glopts->bitrate,
+                    twolame_mpeg_version_name(glopts->version));
+            return -1;
+        }
     }
     // Convert the max VBR bitrate to the an index 
     glopts->vbr_upper_index = twolame_get_bitrate_index(glopts->vbr_max_bitrate, header->version);
@@ -264,6 +270,7 @@ int twolame_init_params(twolame_options * glopts)
             fprintf(stderr, "Chosen bitrate of %dkbps for samplerate of %d Hz.\n",
                     glopts->bitrate, glopts->samplerate_out);
         }
+        glopts->freeformat = FALSE;   // no sense in requiring freeformat encoding without setting a bitrate
     }
 
     /* Can't do DAB and energylevel extensions at the same time Because both of them think they're

--- a/libtwolame/twolame.h
+++ b/libtwolame/twolame.h
@@ -371,6 +371,15 @@ extern "C" {
     DLL_EXPORT const char *twolame_get_version_name(twolame_options * glopts);
 
 
+/** Set the freeformat strem mode.
+ *
+ *	\param glopts	pointer to twolame options pointer
+ *	\param freef	freeformat mode ( TRUE / FALSE )
+ *	\return			0
+ */
+    DLL_EXPORT int twolame_set_freeformat(twolame_options * glopts, int freef);
+
+
 /** Get the number of bytes per MPEG audio frame, for current settings.
  *
  *	\param glopts			pointer to twolame options pointer


### PR DESCRIPTION
A very few modifications allow for encoding in MPEG1/2 free format also.
I did some tests encoding in both MPEG1 and 2, with and without padding, with and without crc protection and everything seems to be working fine.