### PR TITLE
Fixed progress counter

### DIFF
--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -748,11 +748,13 @@ int main(int argc, char **argv)
             exit(ERR_WRITING_OUTPUT);
         }
         else {
-            fprintf(stderr, "\rEncoding frame: %i", frame_count);
-            if (total_frames) {
-                fprintf(stderr, "/%i (%i%%)", total_frames, (frame_count * 100) / total_frames);
+            if (twolame_get_verbosity(encopts) > 0) {
+                fprintf(stderr, "\rEncoding frame: %i", frame_count);
+                if (total_frames) {
+                    fprintf(stderr, "/%i (%i%%)", total_frames, (frame_count * 100) / total_frames);
+                }
+                fflush(stderr);
             }
-            fflush(stderr);
         }
         total_bytes += bytes_out;
     }


### PR DESCRIPTION
The progress frame counter now always reaches 100% at the end of the encoding.