### PR TITLE
Check for invalid bitrate/channel usage

### DIFF
--- a/libtwolame/twolame.c
+++ b/libtwolame/twolame.c
@@ -274,6 +274,29 @@ int twolame_init_params(twolame_options * glopts)
         glopts->freeformat = FALSE;   // no sense in requiring freeformat encoding without setting a bitrate
     }
 
+    /* Check for bitrate validity */
+    if (glopts->version == TWOLAME_MPEG1
+        &&
+        !glopts->freeformat
+        &&
+        !glopts->vbr) {
+        /* some limitation apply for MPEG1 when CBR and freeformat is not selected */
+        if (glopts->mode == TWOLAME_MONO) {
+            if (glopts->bitrate > 192) {
+                fprintf(stderr, "twolame_init_params(): %dkbps is an invalid bitrate for mono encoding.\n",
+                        glopts->bitrate);
+                return -1;
+            }
+        }
+        else {
+            if (glopts->bitrate < 64 || glopts->bitrate == 80) {
+                fprintf(stderr, "twolame_init_params(): %dkbps is an invalid bitrate for 2ch encoding.\n",
+                        glopts->bitrate);
+                return -1;
+            }
+        }
+    }
+
     /* Can't do DAB and energylevel extensions at the same time Because both of them think they're
        the only ones inserting information into the ancillary section of the frame */
     if (glopts->do_dab && glopts->do_energy_levels) {


### PR DESCRIPTION
Prevent the library from creating invalid file because of invalid channel/bitrate combinations.