### PR TITLE
Make operation clear

### DIFF
--- a/libtwolame/encode.c
+++ b/libtwolame/encode.c
@@ -479,13 +479,8 @@ void write_bit_alloc(twolame_options * glopts, unsigned int bit_alloc[2][SBLIMIT
     int sb, ch;
 
     for (sb = 0; sb < sblimit; sb++) {
-        if (sb < jsbound) {
-            for (ch = 0; ch < ((sb < jsbound) ? nch : 1); ch++) {
-                buffer_putbits(bs, bit_alloc[ch][sb], nbal[line[glopts->tablenum][sb]]);
-                glopts->num_crc_bits += nbal[line[glopts->tablenum][sb]];
-            }
-        } else {
-            buffer_putbits(bs, bit_alloc[0][sb], nbal[line[glopts->tablenum][sb]]);
+        for (ch = 0; ch < ((sb < jsbound) ? nch : 1); ch++) {
+            buffer_putbits(bs, bit_alloc[ch][sb], nbal[line[glopts->tablenum][sb]]);
             glopts->num_crc_bits += nbal[line[glopts->tablenum][sb]];
         }
     }


### PR DESCRIPTION
The function "write_bit_alloc" may be made simpler, while still doing its job.
It is not speed optimized, though.
Easy to read, for sure.