### PR TITLE
Fix compilation on mingw or mxe cross compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,7 +161,10 @@ if test "$USE_MAINTAINER_MODE" = yes; then
 	AC_SUBST(WARNING_CFLAGS)
 fi
 
-
+dnl Required for linking binaries to static lib
+if test $enable_static = yes; then
+   CFLAGS+=" -DLIBTWOLAME_STATIC"
+fi
 
 dnl ############## Output files
 

--- a/win32/configwin.h
+++ b/win32/configwin.h
@@ -50,6 +50,7 @@
 
 /* Name of package */
 #define PACKAGE "libtwolame"
+#define PACKAGE_URL "http://www.twolame.org/"
 
 /* The size of a `float', as computed by sizeof. */
 #define SIZEOF_FLOAT 4


### PR DESCRIPTION
These commits fix compilation on mingw. LIBTWOLAME_STATIC must be defined or else the symbols are missing in the static lib when linking.

Sample configuration:
```bash
$ export PATH=/opt/mxe/usr/bin:$PATH
$ ./configure --enable-static --disable-shared --host=x86_64-w64-mingw32.static
```