### PR TITLE
Fix padding

### DIFF
--- a/frontend/frontend.c
+++ b/frontend/frontend.c
@@ -196,7 +196,7 @@ static void usage_long()
     fprintf(stderr, "\t    --original           mark as original (default)\n");
     fprintf(stderr, "\t    --private-ext        set the private extension bit\n");
     fprintf(stderr, "\t-p, --protect            enable CRC error protection\n");
-    fprintf(stderr, "\t-d, --padding            force padding bit/frame on\n");
+    fprintf(stderr, "\t-d, --padding            enable frame padding\n");
     fprintf(stderr, "\t-R, --reserve-bits num   set number of reserved bits in each frame\n");
     fprintf(stderr, "\t-e, --deemphasis emp     de-emphasis n/5/c (default: (n)one)\n");
     fprintf(stderr, "\t-E, --energy             turn on energy level extensions\n");

--- a/libtwolame/availbits.c
+++ b/libtwolame/availbits.c
@@ -33,7 +33,6 @@ struct slotinfo {
     FLOAT frac;
     int whole;
     FLOAT lag;
-    int extra;
 } slots;
 
 
@@ -42,8 +41,6 @@ int available_bits(twolame_options * glopts)
 {
     frame_header *header = &glopts->header;
     int adb;
-
-    slots.extra = 0;            /* be default, no extra slots */
 
     slots.average = (1152.0 / ((FLOAT) glopts->samplerate_out / 1000.0))
                     * ((FLOAT) glopts->bitrate / 8.0);
@@ -58,16 +55,14 @@ int available_bits(twolame_options * glopts)
     if (slots.frac != 0 && glopts->padding && glopts->vbr == FALSE) {
         if (slots.lag > (slots.frac - 1.0)) {   /* no padding for this frame */
             slots.lag -= slots.frac;
-            slots.extra = 0;
             header->padding = 0;
         } else {                /* padding */
-            slots.extra = 1;
             header->padding = 1;
             slots.lag += (1 - slots.frac);
         }
     }
 
-    adb = (slots.whole + slots.extra) * 8;
+    adb = slots.whole * 8;
 
     return adb;
 }

--- a/libtwolame/twolame.c
+++ b/libtwolame/twolame.c
@@ -595,9 +595,8 @@ static int encode_frame(twolame_options * glopts, bit_stream * bs)
         buffer_put1bit(bs, 0);
 
 
-    /* MFC July 03 FIXME Write an extra byte for 16/24/32/48 input when padding is on. Something
-       must be going astray with the frame size calcs. This fudge works fine for the moment */
-    if ((glopts->header.samplerate_idx != 0) && (glopts->padding))  // i.e. not a 44.1 or 22kHz
+    /* pad the current frame when needed */
+    if (glopts->header.padding)
         // input file
         buffer_putbits(bs, 0, 8);
 

--- a/libtwolame/twolame.c
+++ b/libtwolame/twolame.c
@@ -160,7 +160,7 @@ static int init_header_info(twolame_options * glopts)
         return -1;
     }
     // Copy accross the other settings
-    header->padding = glopts->padding;
+    header->padding = 0; /* when requested, padding will be evaluated later for this frame */
     header->private_extension = glopts->private_extension;
     header->mode = glopts->mode;
     header->mode_ext = 0;

--- a/tests/test.pl
+++ b/tests/test.pl
@@ -51,7 +51,7 @@ my $encoding_parameters = [
     'total_frames' => 22,
     'total_bytes' => 13792,
     'total_samples' => 25344,
-    'output_md5sum' => 'fef3bb4926978e56822d33eaa89208d2'
+    'output_md5sum' => 'b7937b5f2ea56460afaeee6f1a5dc77f'
   },
   {
     # Test Case 3 (MPEG-2 test)
@@ -71,7 +71,7 @@ my $encoding_parameters = [
     'total_frames' => 11,
     'total_bytes' => 2298,
     'total_samples' => 12672,
-    'output_md5sum' => '3175f5332040aaad42b00823cd1ec913'
+    'output_md5sum' => '336027628adcfd5f0bb02863920fd6f1'
   },
   {
     # Test Case 4 (error protection test)


### PR DESCRIPTION
With this bunch of commits the padding is only applied when requested AND needed (so in case of 22.05 kHz and 44.1 kHz), frame size is always set at the same value and an int is saved.