### PR TITLE
build: fix when maintainer mode disabled

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -6,10 +6,13 @@ SUBDIRS=html
 ##    xmlto:	http://cyberelk.net/tim/xmlto/
 ##
 
-## Man Page
-man_MANS = twolame.1
+EXTRA_DIST =
+MAINTAINERCLEANFILES =
 
 if MAINTAINER_MODE
+
+## Man Page
+man_MANS = twolame.1
 
 twolame.1.xml: twolame.1.txt
 	@PATH_ASCIIDOC@ -d manpage -b docbook -o twolame.1.xml twolame.1.txt
@@ -17,9 +20,10 @@ twolame.1.xml: twolame.1.txt
 twolame.1: twolame.1.xml
 	@PATH_XMLTO@ man twolame.1.xml
 
-endif
+EXTRA_DIST += twolame.1 twolame.1.xml
+MAINTAINERCLEANFILES = twolame.1 twolame.1.xml
 
-MAINTAINERCLEANFILES=twolame.1 twolame.1.xml
+endif
 
 pkgdocdir = @docdir@
 pkgdoc_DATA = \
@@ -27,8 +31,7 @@ pkgdoc_DATA = \
 	psycho.txt \
 	vbr.txt
 
-EXTRA_DIST = \
-	$(man_MANS) \
+EXTRA_DIST += \
 	$(pkgdoc_DATA) \
 	dist10-text/common.txt \
 	dist10-text/commonh.txt \
@@ -37,5 +40,4 @@ EXTRA_DIST = \
 	dist10-text/musicin.txt \
 	dist10-text/psy.txt \
 	dist10-text/tonal.txt \
-	index.txt \
-	twolame.1.txt
+	index.txt

--- a/doc/html/Makefile.am
+++ b/doc/html/Makefile.am
@@ -31,12 +31,12 @@ stylesheet_files = \
     twolame-manpage.css \
     twolame.css
 
-
-pkghtml_DATA = $(doxygen_files) $(asciidoc_files) $(stylesheet_files)
-EXTRA_DIST = Doxyfile.in $(pkghtml_DATA)
-
+EXTRA_DIST = Doxyfile.in
 
 if MAINTAINER_MODE
+
+pkghtml_DATA = $(doxygen_files) $(asciidoc_files) $(stylesheet_files)
+EXTRA_DIST += Doxyfile.in $(pkghtml_DATA)
 
 $(doxygen_files): Doxyfile $(top_srcdir)/libtwolame/twolame.h
 	@PATH_DOXYGEN@
@@ -66,6 +66,7 @@ vbr.html: $(top_srcdir)/doc/vbr.txt
 twolame.1.html: $(top_srcdir)/doc/twolame.1.txt
 	$(asciidoc) -d manpage -o $@ $<
 
+MAINTAINERCLEANFILES = $(doxygen_files) $(asciidoc_files)
+
 endif
 
-MAINTAINERCLEANFILES = $(doxygen_files) $(asciidoc_files)


### PR DESCRIPTION
If maintainer mode is disabled explicitly, the build should succeed
skipping man pages and doxygen documentation. Currently this was
breaking because there were rules referencing built files out of the
MAINTAINER_MODE block.

In doc/html, there shouldn't be rules requiring doxygen.css or any
other generated file out of the MAINTAINER_MODE block:

    make[2]: Entering directory '/home/aleksander/Development/clients/azimut/twolame/doc/html'
    make[2]: *** No rule to make target 'doxygen.css', needed by 'all-am'.  Stop.
    make[2]: Leaving directory '/home/aleksander/Development/clients/azimut/twolame/doc/html'
    make[1]: *** [Makefile:480: all-recursive] Error 1
    make[1]: Leaving directory '/home/aleksander/Development/clients/azimut/twolame/doc'
    make: *** [Makefile:468: all-recursive] Error 1

In doc/, there shouldn't be rules requiring twolame.1 or any other
generated file out of the MAINTAINER_MODE block:

    make[2]: Entering directory '/home/aleksander/Development/clients/azimut/twolame/doc'
    make[2]: *** No rule to make target 'twolame.1', needed by 'all-am'.  Stop.
    make[2]: Leaving directory '/home/aleksander/Development/clients/azimut/twolame/doc'
    make[1]: *** [Makefile:480: all-recursive] Error 1
    make[1]: Leaving directory '/home/aleksander/Development/clients/azimut/twolame/doc'
    make: *** [Makefile:468: all-recursive] Error 1