### PR TITLE
Set libsndfile for auto scaling floating point input source

### DIFF
--- a/frontend/audioin_sndfile.c
+++ b/frontend/audioin_sndfile.c
@@ -153,6 +153,8 @@ audioin_t *open_audioin_sndfile(char *filename, SF_INFO * sfinfo)
     audioin->error_str = error_str_sndfile;
     audioin->close = close_sndfile;
 
+    /* enable scaling for floating point input files */
+    sf_command(audioin->file, SFC_SET_SCALE_FLOAT_INT_READ, NULL, SF_TRUE);
 
     return audioin;
 }


### PR DESCRIPTION
This missing setting for libsndfile fixes #58 