### PR TITLE
Exact frame size

### DIFF
--- a/libtwolame/util.c
+++ b/libtwolame/util.c
@@ -160,7 +160,7 @@ int twolame_get_framelength(twolame_options * glopts)
 {
     int bytes = 144 * (glopts->bitrate * 1000) / glopts->samplerate_out;
 
-    if (glopts->padding)
+    if ((glopts->header).padding)
         bytes++;
 
     return bytes;


### PR DESCRIPTION
When enabling padding for a bitstream, the code wrongly returns any frame size as padded.
Now this is fixed.