### PR TITLE
Fix for not allowed bitrate

### DIFF
--- a/libtwolame/util.c
+++ b/libtwolame/util.c
@@ -85,12 +85,9 @@ int twolame_get_bitrate_index(int bitrate, TWOLAME_MPEG_version version)
         return -1;
     }
 
-    while (index < 15) {
+    while (++index < 15)
         if (bitrate_table[version][index] == bitrate)
             break;
-        else
-            ++index;
-    }
 
     if (index == 15) {
         fprintf(stderr,


### PR DESCRIPTION
The library currently takes as good a bitrate = 0 when encoding mpeg2 streams (16, 22, 24 khz).
Now this is avoided and the given bitrate is detected as wrong.