### PR TITLE
Add Libs.Private to twolame.pc for static builds

### DIFF
--- a/twolame.pc.in
+++ b/twolame.pc.in
@@ -8,4 +8,5 @@ Description: An optimized MPEG Audio Layer 2 encoder
 Requires:
 Version: @VERSION@
 Libs: -L${libdir} -ltwolame
+Libs.Private: @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
This is needed to properly resolve dependencies like libm
when linking to static builds of twolame.