### PR TITLE
Better fix for not allowed bitrate

### DIFF
--- a/libtwolame/twolame.c
+++ b/libtwolame/twolame.c
@@ -152,12 +152,16 @@ static int init_header_info(twolame_options * glopts)
             return -1;
         }
     }
-    // Convert the max VBR bitrate to the an index
-    glopts->vbr_upper_index = twolame_get_bitrate_index(glopts->vbr_max_bitrate, header->version);
-    if (glopts->vbr_upper_index < 0) {
-        fprintf(stderr, "Not a valid max VBR bitrate for this version: %i\n",
-                glopts->vbr_max_bitrate);
-        return -1;
+    if (glopts->vbr && glopts->vbr_max_bitrate > 0)
+    {
+        /* user required vbr and a specified max bitrate */
+        /* convert max VBR bitrate to an index */
+        glopts->vbr_upper_index = twolame_get_bitrate_index(glopts->vbr_max_bitrate, header->version);
+        if (glopts->vbr_upper_index < 0) {
+            fprintf(stderr, "Not a valid max VBR bitrate for this version: %i\n",
+                    glopts->vbr_max_bitrate);
+            return -1;
+        }
     }
     // Copy accross the other settings
     header->padding = 0; /* when requested, padding will be evaluated later for this frame */

--- a/libtwolame/util.c
+++ b/libtwolame/util.c
@@ -85,12 +85,9 @@ int twolame_get_bitrate_index(int bitrate, TWOLAME_MPEG_version version)
         return -1;
     }
 
-    while (index < 15) {
+    while (++index < 15)
         if (bitrate_table[version][index] == bitrate)
             break;
-        else
-            ++index;
-    }
 
     if (index == 15) {
         fprintf(stderr,


### PR DESCRIPTION
This new PR includes the old fix for not allowed bitrate (which caused a crash when encoding mpeg2 content) and better protection for max bitrate value in vbr encodings. This used to pass before only because `twolame_get_bitrate_index` returned zero, which is wrong result but allowed the check to pass.