### PR TITLE
Fix static linking with libmagic

### DIFF
--- a/libtwolame/bitbuffer.c
+++ b/libtwolame/bitbuffer.c
@@ -31,7 +31,7 @@
 
 
 /*create bit buffer*/
-bit_stream *buffer_init(unsigned char *buffer, int buffer_size)
+bit_stream *bitbuffer_init(unsigned char *buffer, int buffer_size)
 {
     bit_stream *bs = (bit_stream *) TWOLAME_MALLOC(sizeof(bit_stream));
 
@@ -49,7 +49,7 @@ bit_stream *buffer_init(unsigned char *buffer, int buffer_size)
 }
 
 /* Dellocate bit buffer */
-void buffer_deinit(bit_stream ** bs)
+void bitbuffer_deinit(bit_stream ** bs)
 {
 
     if (bs == NULL || *bs == NULL)

--- a/libtwolame/bitbuffer.h
+++ b/libtwolame/bitbuffer.h
@@ -37,11 +37,11 @@ typedef struct bit_stream_struc {
 } bit_stream;
 
 
-bit_stream *buffer_init(unsigned char *buffer, int buffer_size);
-void buffer_deinit(bit_stream ** bs);
+bit_stream *bitbuffer_init(unsigned char *buffer, int buffer_size);
+void bitbuffer_deinit(bit_stream ** bs);
 
 /*return the current bit stream length (in bits)*/
-#define buffer_sstell(bs) (bs->totbit)
+#define bitbuffer_sstell(bs) (bs->totbit)
 
 #endif
 

--- a/libtwolame/energy.c
+++ b/libtwolame/energy.c
@@ -71,7 +71,7 @@ void do_energy_levels(twolame_options * glopts, bit_stream * bs)
     unsigned char rhibyte, rlobyte, lhibyte, llobyte;
 
     // Get the position (in butes) of the end of the mpeg audio frame
-    int frameEnd = buffer_sstell(bs) / 8;
+    int frameEnd = bitbuffer_sstell(bs) / 8;
 
 
     // find the maximum in the left and right channels

--- a/libtwolame/twolame.c
+++ b/libtwolame/twolame.c
@@ -509,7 +509,7 @@ static int encode_frame(twolame_options * glopts, bit_stream * bs)
     glopts->num_crc_bits = 0;
 
     // Store the number of bits initially in the bit buffer
-    initial_bits = buffer_sstell(bs);
+    initial_bits = bitbuffer_sstell(bs);
 
     adb = available_bits(glopts);
 
@@ -638,7 +638,7 @@ static int encode_frame(twolame_options * glopts, bit_stream * bs)
 
 
     // Calulate the number of bits in this frame
-    frameBits = buffer_sstell(bs) - initial_bits;
+    frameBits = bitbuffer_sstell(bs) - initial_bits;
     if (frameBits % 8) {        /* a program failure */
         fprintf(stderr, "Sent %ld bits = %ld slots plus %ld\n", frameBits, frameBits / 8,
                 frameBits % 8);
@@ -688,7 +688,7 @@ int twolame_encode_buffer(twolame_options * glopts,
 
     // now would be a great time to validate the size of the buffer.
     // samples/1152 * sizeof(frame) < mp2buffer_size
-    mybs = buffer_init(mp2buffer, mp2buffer_size);
+    mybs = bitbuffer_init(mp2buffer, mp2buffer_size);
 
     if (mybs != NULL) {
         // Use up all the samples in in_buffer
@@ -719,7 +719,7 @@ int twolame_encode_buffer(twolame_options * glopts,
             if (glopts->samples_in_buffer >= TWOLAME_SAMPLES_PER_FRAME) {
                 int bytes = encode_frame(glopts, mybs);
                 if (bytes <= 0) {
-                    buffer_deinit(&mybs);
+                    bitbuffer_deinit(&mybs);
                     return bytes;
                 }
                 mp2_size += bytes;
@@ -728,7 +728,7 @@ int twolame_encode_buffer(twolame_options * glopts,
         }
 
         // free up the bit stream buffer structure
-        buffer_deinit(&mybs);
+        bitbuffer_deinit(&mybs);
     }
 
     return (mp2_size);
@@ -749,7 +749,7 @@ int twolame_encode_buffer_interleaved(twolame_options * glopts,
 
     // now would be a great time to validate the size of the buffer.
     // samples/1152 * sizeof(frame) < mp2buffer_size
-    mybs = buffer_init(mp2buffer, mp2buffer_size);
+    mybs = bitbuffer_init(mp2buffer, mp2buffer_size);
 
     if (mybs != NULL) {
         // Use up all the samples in in_buffer
@@ -780,7 +780,7 @@ int twolame_encode_buffer_interleaved(twolame_options * glopts,
             if (glopts->samples_in_buffer >= TWOLAME_SAMPLES_PER_FRAME) {
                 int bytes = encode_frame(glopts, mybs);
                 if (bytes <= 0) {
-                    buffer_deinit(&mybs);
+                    bitbuffer_deinit(&mybs);
                     return bytes;
                 }
                 mp2_size += bytes;
@@ -789,7 +789,7 @@ int twolame_encode_buffer_interleaved(twolame_options * glopts,
         }
 
         // free up the bit stream buffer structure
-        buffer_deinit(&mybs);
+        bitbuffer_deinit(&mybs);
     }
 
     return (mp2_size);
@@ -837,7 +837,7 @@ int twolame_encode_buffer_float32(twolame_options * glopts,
 
     // now would be a great time to validate the size of the buffer.
     // samples/1152 * sizeof(frame) < mp2buffer_size
-    mybs = buffer_init(mp2buffer, mp2buffer_size);
+    mybs = bitbuffer_init(mp2buffer, mp2buffer_size);
 
     if (mybs != NULL) {
         // Use up all the samples in in_buffer
@@ -866,7 +866,7 @@ int twolame_encode_buffer_float32(twolame_options * glopts,
             if (glopts->samples_in_buffer >= TWOLAME_SAMPLES_PER_FRAME) {
                 int bytes = encode_frame(glopts, mybs);
                 if (bytes <= 0) {
-                    buffer_deinit(&mybs);
+                    bitbuffer_deinit(&mybs);
                     return bytes;
                 }
                 mp2_size += bytes;
@@ -875,7 +875,7 @@ int twolame_encode_buffer_float32(twolame_options * glopts,
         }
 
         // free up the bit stream buffer structure
-        buffer_deinit(&mybs);
+        bitbuffer_deinit(&mybs);
     }
 
     return (mp2_size);
@@ -896,7 +896,7 @@ int twolame_encode_buffer_float32_interleaved(twolame_options * glopts,
 
     // now would be a great time to validate the size of the buffer.
     // samples/1152 * sizeof(frame) < mp2buffer_size
-    mybs = buffer_init(mp2buffer, mp2buffer_size);
+    mybs = bitbuffer_init(mp2buffer, mp2buffer_size);
 
     if (mybs != NULL) {
         // Use up all the samples in in_buffer
@@ -925,7 +925,7 @@ int twolame_encode_buffer_float32_interleaved(twolame_options * glopts,
             if (glopts->samples_in_buffer >= TWOLAME_SAMPLES_PER_FRAME) {
                 int bytes = encode_frame(glopts, mybs);
                 if (bytes <= 0) {
-                    buffer_deinit(&mybs);
+                    bitbuffer_deinit(&mybs);
                     return bytes;
                 }
                 mp2_size += bytes;
@@ -934,7 +934,7 @@ int twolame_encode_buffer_float32_interleaved(twolame_options * glopts,
         }
 
         // free up the bit stream buffer structure
-        buffer_deinit(&mybs);
+        bitbuffer_deinit(&mybs);
     }
 
     return (mp2_size);
@@ -953,7 +953,7 @@ int twolame_encode_flush(twolame_options * glopts, unsigned char *mp2buffer, int
         return 0;
     }
     // Create bit stream structure
-    mybs = buffer_init(mp2buffer, mp2buffer_size);
+    mybs = bitbuffer_init(mp2buffer, mp2buffer_size);
 
     if (mybs != NULL) {
         // Pad out the PCM buffers with 0 and encode the frame
@@ -966,7 +966,7 @@ int twolame_encode_flush(twolame_options * glopts, unsigned char *mp2buffer, int
         glopts->samples_in_buffer = 0;
 
         // free up the bit stream buffer structure
-        buffer_deinit(&mybs);
+        bitbuffer_deinit(&mybs);
     }
 
     return mp2_size;


### PR DESCRIPTION
libmagic (from file package) already provides the buffer_init function
so to avoid a build failure for applications wanting to statically link
with twolame and libmagic (for example sox), rename buffer_init into
bitbuffer_init (also rename buffer_deinit into bitbuffer_deinit and
buffer_sstell into bitbuffer_sstell for consistency)

Fixes:
 - http://autobuild.buildroot.org/results/b3fc62e7f372fe595966e84091c11ccdb4cfa77c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>