### PR TITLE
add -no-undefined for compilation on Windows

### DIFF
--- a/libtwolame/Makefile.am
+++ b/libtwolame/Makefile.am
@@ -3,7 +3,7 @@ AM_CFLAGS = -I ../build/ $(WARNING_CFLAGS)
 lib_LTLIBRARIES = libtwolame.la
 include_HEADERS = twolame.h
 
-libtwolame_la_LDFLAGS  = -export-dynamic -version-info @TWOLAME_SO_VERSION@
+libtwolame_la_LDFLAGS  = -export-dynamic -version-info @TWOLAME_SO_VERSION@ -no-undefined
 libtwolame_la_SOURCES = \
 	ath.c \
 	ath.h \


### PR DESCRIPTION
this flags as no side effect on linux as anyway all the symbols should be defined