### PR TITLE
Fix detection of git clone

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ NEWS:
 	[ -f NEWS.md ] && cat $(top_srcdir)/NEWS.md > $@ || true
 
 ChangeLog:
-	[ -d .git ] && git log > ChangeLog || true
+	[ -e .git ] && git log > ChangeLog || true
 
 pkgdocdir = @docdir@
 pkgdoc_DATA = \


### PR DESCRIPTION
If it's cloned as a git submodule, .git will be a single-line file, not a directory.